### PR TITLE
Using /doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
It would be helpful for those of us using this plugin as a git submodule and Pathogen to have a .gitignore containing /doc/tags. Otherwise, git will mark the submodule as 'dirty' all the time.
