### PR TITLE
FIX: align double byte character set 

### DIFF
--- a/autoload/tabular.vim
+++ b/autoload/tabular.vim
@@ -55,7 +55,7 @@ function! s:Strlen(string)
       let rv += &ts - i
       let i = 0
     else
-      let rv += 1
+      let rv += strdisplaywidth(char)
       let i = (i + 1) % &ts
     endif
   endfor


### PR DESCRIPTION
Hey, I found tabular can't align double byte character correctly, so I fix it :)
