### PR TITLE
Always strip trailing spaces in TabularizeStrings

### DIFF
--- a/autoload/tabular.vim
+++ b/autoload/tabular.vim
@@ -231,9 +231,7 @@ function! tabular#TabularizeStrings(strings, delim, ...)
       continue " Leave non-matching lines unchanged for GTabularize
     endif
 
-    if line[0] !~ '^\s*$'
-      let line[0] = s:StripTrailingSpaces(line[0])
-    endif
+    let line[0] = s:StripTrailingSpaces(line[0])
     if len(line) >= 3
       for i in range(2, len(line)-1, 2)
         let line[i] = s:StripLeadingSpaces(s:StripTrailingSpaces(line[i]))


### PR DESCRIPTION
Currently, trailing spaces are only stripped from the first element in a line if it contains non-whitespace characters, however this causes padding creep.

Given a block like

```
    foo   => bar
    beezlebub
          => debil
    john  => doe
```

`:GTab /=>/` will move the `=>` column to the right by one instead of to the left by one.  Similarly, using `:Tab /=>/` twice will first align the column as expected, but then shift the column one to the right every time you repeat the command.

This is because the leading whitespace on the `=> debil` line is considered when calculating the max line length.

Stripping the trailing whitespace (which is all of the whitespace in this case) ensures the lines are all aligned, only taking into account relevant content.
