### PR TITLE
Option to not load TabularMaps

### DIFF
--- a/after/plugin/TabularMaps.vim
+++ b/after/plugin/TabularMaps.vim
@@ -1,4 +1,4 @@
-if !exists(':Tabularize')
+if !exists(':Tabularize') || (exists("g:no_default_tabular_maps") && g:no_default_tabular_maps)
   finish " Tabular.vim wasn't loaded
 endif
 


### PR DESCRIPTION
If not needed, then skip reading of file by setting "g:no_default_tabular_maps=1" in "~/.vimrc".
