### PR TITLE
Add spaces Pipeline

### DIFF
--- a/after/plugin/TabularMaps.vim
+++ b/after/plugin/TabularMaps.vim
@@ -34,6 +34,7 @@ AddTabularPattern!  assignment      /[|&+*/%<>=!~-]\@<!\([<>!=]=\|=\~\)\@![|&+*/
 AddTabularPattern!  two_spaces      /  /l0
 
 AddTabularPipeline! multiple_spaces /  / map(a:lines, "substitute(v:val, '   *', '  ', 'g')") | tabular#TabularizeStrings(a:lines, '  ', 'l0')
+AddTabularPipeline! spaces          / /  map(a:lines, "substitute(v:val, '  *' , ' ' , 'g')") | tabular#TabularizeStrings(a:lines, ' ' , 'l0')
 
 AddTabularPipeline! argument_list   /(.*)/ map(a:lines, 'substitute(v:val, ''\s*\([(,)]\)\s*'', ''\1'', ''g'')')
                                        \ | tabular#TabularizeStrings(a:lines, '[(,)]', 'l0')


### PR DESCRIPTION
This pipeline is to align space-separated fields. As long as there is one space, there is a separate field. Yet, the pipeline `multiple_spaces` cannot capture that.